### PR TITLE
bugfix: fix wrong #ifeq range in src/tray/main.py

### DIFF
--- a/src/tray/main.py
+++ b/src/tray/main.py
@@ -40,9 +40,9 @@ grp.add_argument('--qt5',
 grp.add_argument('--qt6',
     help='Use PyQt6',
     dest='qt_version', action='store_const', const=6)
+#endif
 
 opts, qt_args = argp.parse_known_args()
-#endif
 
 # =============================================================================
 # Import Qt5/Qt6


### PR DESCRIPTION
The #if range is too large, wrong includes the part of argument parsing.

When build with `make QT_VERSION=6` or `make QT_VERSION=5`, the #ifeq statement well skip this line `opts, qt_args = argp.parse_known_args()`, `qt_args` will not exist.

```
#ifeq QT_VERSION 0
grp = argp.add_argument_group(title='Qt version')

grp.add_argument('--qt5',
    help='Use PyQt5',
    dest='qt_version', action='store_const', const=5)

grp.add_argument('--qt6',
    help='Use PyQt6',
    dest='qt_version', action='store_const', const=6)

opts, qt_args = argp.parse_known_args()
#endif
```

When run `nbfc-qt-tray.py`, python will raise NameError.

```
Traceback (most recent call last):
  File "/nbfc-qt/./nbfc-qt-tray.py", line 3751, in <module>
    TrayApp().run()
    ~~~~~~~^^
  File "/nbfc-qt/./nbfc-qt-tray.py", line 3722, in __init__
    self.app = QApplication([sys.argv[0]] + qt_args)
                                            ^^^^^^^
NameError: name 'qt_args' is not defined
```

```
class TrayApp:
    def __init__(self):
        self.app = QApplication([sys.argv[0]] + qt_args)
        self.app.setQuitOnLastWindowClosed(False)
        self.ctrl = FanControlWidget()
```